### PR TITLE
fix toputils: make it more robust to paths that contain `_tops`

### DIFF
--- a/_utils/toputils.py
+++ b/_utils/toputils.py
@@ -332,7 +332,7 @@ class TopUtils(PathUtils):
             except SaltRenderError:
                 return ''
 
-        if relpath.startswith(self.topd_directory):  # pylint: disable=E1101
+        if relpath.startswith(self.topd_directory + os.sep):  # pylint: disable=E1101
             relpath = relpath.split(self.topd_directory + os.sep)[
                 1
             ]  # pylint: disable=E1101

--- a/_utils/toputils.py
+++ b/_utils/toputils.py
@@ -333,7 +333,7 @@ class TopUtils(PathUtils):
                 return ''
 
         if relpath.startswith(self.topd_directory + os.sep):  # pylint: disable=E1101
-            relpath = relpath.split(self.topd_directory + os.sep)[
+            relpath = relpath.split(self.topd_directory + os.sep, maxsplit=1)[
                 1
             ]  # pylint: disable=E1101
 


### PR DESCRIPTION
Previously, the code was simply splitting paths by the text `_tops/`.

There were two errors:

1. It was not checked first that the path started with `_tops/` (only `_tops`).
2. It would cut off paths that contain `_tops/` because we were taking the first index of the split only, so `_tops/this_is_not_a_tops/test.top` would result in a relpath of `_tops/this_is_not_a` (cut off in the middle of the directory).

Fixes [#9949](https://github.com/QubesOS/qubes-issues/issues/9949).